### PR TITLE
Move definition of min outside of #ifdef UBJW_DISASSEMBLY_MODE

### DIFF
--- a/ubjw.c
+++ b/ubjw.c
@@ -265,15 +265,16 @@ void ubjw_write_char(ubjw_context_t* ctx, char out)
 	priv_ubjw_write_raw_char(ctx, out);
 }
 
-#ifdef UBJW_DISASSEMBLY_MODE
-#include <stdarg.h>  
-#define DISASSEMBLY_PRINT_BUFFER_SIZE 1024
 #ifndef min
 static inline size_t min(size_t x,size_t y)
 {
 	return x < y ? x : y;
 }
 #endif
+
+#ifdef UBJW_DISASSEMBLY_MODE
+#include <stdarg.h>  
+#define DISASSEMBLY_PRINT_BUFFER_SIZE 1024
 
 static inline priv_disassembly_print(ubjw_context_t* ctx, const char* format,...)
 {


### PR DESCRIPTION
If UBJW_DISASSEMBLY_MODE is not defined, min is not defined and priv_ubjw_write_byteswap is using an undefined min function. I fixed this by moving min outside of #ifdef UBJW_DISASSEMBLY_MODE