### PR TITLE
Fixed parsing closing tags of unsized containers

### DIFF
--- a/ubjr.c
+++ b/ubjr.c
@@ -365,6 +365,7 @@ static inline ubjr_array_t priv_ubjr_read_raw_array(ubjr_context_t* ctx)
 			}
 			priv_ubjr_read_to_ptr(ctx,(uint8_t*)myarray.values + ls*myarray.size,myarray.type);
 		}
+		priv_ubjr_context_getc(ctx); // read the closing ']'
 	}
 	else
 	{
@@ -418,6 +419,7 @@ static inline ubjr_object_t priv_ubjr_read_raw_object(ubjr_context_t* ctx)
 			priv_ubjr_read_to_ptr(ctx, (uint8_t*)(myobject.keys + myobject.size), UBJ_STRING);
 			priv_ubjr_read_to_ptr(ctx, (uint8_t*)myobject.values + ls*myobject.size, myobject.type);
 		}
+		priv_ubjr_context_getc(ctx); // read the closing '}'
 	}
 	else
 	{


### PR DESCRIPTION
The closing tag was peeked in the loop, but wasn't popped from the stream once found. This caused the rest of the message to be corrupted.

Note that the code has poor handling of stream errors. In my case this bug caused an infinite recursion which resulted in a stack overflow crash. This should be considered a security vulnerability: an attacker could insert a stray `}` in a UBJSON document and cause a denial-of-service or worse. This problem is not fixed by this PR.
